### PR TITLE
Check fluid allowance in FFFluidUtils

### DIFF
--- a/common/src/main/java/traben/flowing_fluids/FFFluidUtils.java
+++ b/common/src/main/java/traben/flowing_fluids/FFFluidUtils.java
@@ -373,6 +373,7 @@ public class FFFluidUtils {
                 && !FlowingFluids.isManeuveringFluids
                 && !originalState.getFluidState().isEmpty()// assert that the original state is a fluid
                 && originalState.getFluidState().getType() instanceof FlowingFluid flowSource
+                && FlowingFluids.config.isFluidAllowed(flowSource) // check if the fluid is not in the ignored list
                 && !state.isAir() // covers most block breaking updates
                 && state.getFluidState().isEmpty()// not placing a waterlogged or fluid block
                 && !((flags & 64) == 64) //Piston moved flag


### PR DESCRIPTION
This pull request introduces an additional check to the fluid displacement logic to ensure only allowed fluids are processed. The change helps prevent unwanted fluid types from being affected by the displacement operation.

Fluid displacement logic:
* Added a call to `FlowingFluids.config.isFluidAllowed(flowSource)` in `displaceFluids` to verify that the fluid type is permitted before proceeding with displacement.

Implemented to fix [this](https://discord.com/channels/950942125225283634/1428585897426817201) discord bug.