### PR TITLE
Fix Sable/Aeronautics launch crash and NeoForge config getting reset on every server start

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
 
+[?]
+- fixed a launch crash when Sable / Create: Aeronautics was installed
+- fixed an issue preventing the config file from loading or updating properly on NeoForge
+- fixed auto performance overwriting changes in the saved config file
+
 [1.0.5]
 - updated to 26.1
 - fixed the sea level override command

--- a/src/main/java/traben/flowing_fluids/FlowingFluidsInit.java
+++ b/src/main/java/traben/flowing_fluids/FlowingFluidsInit.java
@@ -75,6 +75,7 @@ public class FlowingFluidsInit implements ModInitializer {
 //$$ public class FlowingFluidsInit {
 //$$     public FlowingFluidsInit() {
 //$$         NeoForge.EVENT_BUS.register(FlowingFluidsInit.class);
+//$$         FlowingFluids.start();
 //$$     }
 //$$
 //$$     @SubscribeEvent

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinServer_AutoPerformance.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinServer_AutoPerformance.java
@@ -30,9 +30,9 @@ public abstract class MixinServer_AutoPerformance {
         if (!FlowingFluids.config.enableMod || !FlowingFluids.config.autoPerformanceMode.enabled())
             return;
 
-        // reset auto to default on server close
+        // reset auto-perf level for the next server start. Do NOT saveConfig:
+        // auto-perf adjustments must never overwrite the user's saved config.
         FFAutoPerformance.resetAuto();
-        FlowingFluids.saveConfig();
 
         lastSysTimeAdjusted = 0;
     }
@@ -46,9 +46,9 @@ public abstract class MixinServer_AutoPerformance {
         if (time - lastSysTimeAdjusted < FlowingFluids.config.autoPerformanceUpdateRateSeconds * 1000L) return;
 
         if (lastSysTimeAdjusted == 0) {
-            // first run, old config may have been retained from last session via crash or who knows what, it's easier to reset always than try to parse
+            // first run; reset in-memory auto-perf level. Do NOT saveConfig here:
+            // auto-perf adjustments must never overwrite the user's saved config.
             FFAutoPerformance.resetAuto();
-            FlowingFluids.saveConfig();
         }
 
         lastSysTimeAdjusted = time;

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinWaterPushing.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinWaterPushing.java
@@ -30,8 +30,10 @@ public class MixinWaterPushing {
 
     @ModifyExpressionValue(
             method = METHOD_NAME,
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;isPushedByFluid()Z")
-
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;isPushedByFluid()Z"),
+            // Sable (used by Create: Aeronautics) overwrites the target method and removes this INVOKE.
+            // Allow the injection to silently no-op in that case rather than crashing the game.
+            require = 0
     )
     private boolean ff$isPushed(final boolean original) {
         if (!original) return false;


### PR DESCRIPTION
Closes #141, closes #162, closes #163, closes #166.

This PR bundles three closely related fixes — the second and third together cause the symptoms in #141 and #163, and the first is a separate but coincident NeoForge crash reported in #162 / #166.

## 1. `MixinWaterPushing` — Sable / Create: Aeronautics launch crash (#162, #166)

With Flowing Fluids + Sable (used as a dependency by Create: Aeronautics) on NeoForge 1.21.1, the game crashes on launch with:

```
Critical injection failure: Callback method ff$isPushed(Z)Z in
flowing_fluids.mixins.json:MixinWaterPushing from mod flowing_fluids
failed injection check, (0/1) succeeded. Scanned 0 target(s).
```

Sable rewrites `Entity.updateFluidHeightAndDoFluidPushing` for its buoyancy overhaul and removes the call to `Entity.isPushedByFluid()`, which is the `@ModifyExpressionValue` target. With `defaultRequire: 1` from `flowing_fluids.mixins.json`, this aborts class loading and brings down the JVM.

Adding `require = 0` lets the injector silently no-op when the target is absent. This is the same pattern already used in `MixinConcretePowderBlock` and `MixinFluidRenderer2`. With Sable installed, Flowing Fluids' per-entity push toggles (`waterFlowAffectsPlayers` etc.) won't take effect on entities Sable has taken over — but the game launches, and where Sable hasn't touched things, the toggles still work as before.

## 2. `FlowingFluidsInit` — NeoForge never calls `FlowingFluids.start()`

The Fabric and Forge entry points both call `FlowingFluids.start()` (which loads the JSON config and populates infinite-biome / non-displacer tables). The NeoForge constructor only registers an event-bus subscriber and never calls it. The result on every NeoForge launch:

- `loadConfig()` never runs, so the user's on-disk JSON is ignored;
- `FlowingFluids.config` stays at the field-initialised defaults;
- infinite-biome / non-displacer tables are empty (sponges don't absorb, ocean biomes don't refill, etc.).

Fix: call `FlowingFluids.start()` from the NeoForge constructor for parity with the other two loaders.

## 3. `MixinServer_AutoPerformance` — auto-perf overwrites the user's saved config

`MixinServer_AutoPerformance` called `FlowingFluids.saveConfig()` in two places:

- on **server shutdown**, right after `FFAutoPerformance.resetAuto()` reset perf-related fields to auto-perf-level-0 defaults;
- on the **first server tick**, same pattern.

Since auto-perf is enabled by default, this fired for almost everyone — and it serialised whatever was currently in `FlowingFluids.config` over the user's `flowing_fluids.json`. On Forge / Fabric this only reverted perf fields (`waterTickDelay`, `lavaTickDelay`, `waterFlowDistance`); on NeoForge — because Bug 2 above means `config` is always the field-initialised default object — it rewrote the **entire** file with defaults, which is why #163 reports `farmlandDrainWaterChance` flipping back to the default `0.01` only on NeoForge.

Fix: remove both `saveConfig()` calls. Auto-perf adjustments are intentional in-memory runtime tuning driven by live MSPT and have no business persisting. The `resetAuto()` calls are kept (they only mutate in-memory state, which is still desired). After the fix, `flowing_fluids.json` is only ever written when:

- the user runs a `/flowing_fluids` command (via `FFCommands.messageAndSaveConfig`), or
- the file doesn't exist yet (first run, `loadConfig` writes defaults).

## Test plan

- [x] Built `:1.21-neoforge:build` cleanly.
- [x] Tested locally: NeoForge 1.21.1 with Flowing Fluids + Sable + Create: Aeronautics launches without crashing.
- [x] Edit `config/flowing_fluids.json` to set `farmlandDrainWaterChance: 0.0` on NeoForge, launch, confirm file is unchanged after world load and after server stop.
- [ ] Same on Forge 1.20.1 with `waterTickDelay: 8` for regression coverage.
- [ ] Same on Fabric.
- [ ] Confirm auto-perf still adjusts perf fields in memory based on server load, but those adjustments do not appear in the saved JSON after restart.
- [ ] Confirm `/flowing_fluids settings ...` commands still persist (untouched by this PR).
- [ ] Confirm NeoForge sponges/ocean biomes/non-displacers behave correctly now that `start()` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)