### PR TITLE
Fix Create open-ended pipe fluid duplication

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
 - fixed a launch crash when Sable / Create: Aeronautics was installed
 - fixed an issue preventing the config file from loading or updating properly on NeoForge
 - fixed auto performance overwriting changes in the saved config file
+- fixed create pipes still using the vanilla infinite water check to draw water infinitely
 
 [1.0.5]
 - updated to 26.1

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/create/MixinPipe.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/create/MixinPipe.java
@@ -54,7 +54,6 @@ public abstract class MixinPipe{
 //$$         }
 //$$         return blockState;
 //$$     }
-
 //$$
 //$$     /**
 //$$      * Create can treat a source as immediately refillable and return fluid without changing the world.
@@ -84,6 +83,5 @@ public abstract class MixinPipe{
 //$$
 //$$         return false;
 //$$     }
-
 //$$ }
 //#endif

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/create/MixinPipe.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/create/MixinPipe.java
@@ -10,12 +10,15 @@ public abstract class MixinPipe{
 }
 //#else
 //$$
+//$$ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+//$$ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 //$$ import com.simibubi.create.content.fluids.OpenEndedPipe;
 //$$ import com.simibubi.create.infrastructure.config.AllConfigs;
 //$$ import net.minecraft.core.BlockPos;
 //$$ import net.minecraft.world.level.Level;
 //$$ import net.minecraft.world.level.block.Blocks;
 //$$ import net.minecraft.world.level.block.state.BlockState;
+//$$ import net.minecraft.world.level.material.FluidState;
 //$$ import net.minecraft.world.ticks.ScheduledTick;
 //$$ import org.spongepowered.asm.mixin.Pseudo;
 //$$ import org.spongepowered.asm.mixin.Shadow;
@@ -51,5 +54,36 @@ public abstract class MixinPipe{
 //$$         }
 //$$         return blockState;
 //$$     }
+
+//$$
+//$$     /**
+//$$      * Create can treat a source as immediately refillable and return fluid without changing the world.
+//$$      * That is fine for vanilla infinite-fluid behaviour, but it duplicates finite Flowing Fluids fluid.
+//$$      */
+//$$     @WrapOperation(method = "removeFluidFromSpace",
+//$$             at = @At(value = "INVOKE",
+//$$                     target = "Ljava/lang/Object;equals(Ljava/lang/Object;)Z"),
+//$$             remap = false, require = 0)
+//$$     private boolean ff$disableImmediateRefillShortcut(final Object potentiallyFilled,
+//$$                                                       final Object originalFluidState,
+//$$                                                       final Operation<Boolean> original) {
+//$$         final boolean result = original.call(potentiallyFilled, originalFluidState);
+//$$         if (!result) return false;
+//$$
+//$$         if (!FlowingFluids.config.enableMod || FlowingFluids.config.create_infinitePipes) {
+//$$             return true;
+//$$         }
+//$$
+//$$         if (!(originalFluidState instanceof FluidState fluidState)) {
+//$$             return true;
+//$$         }
+//$$
+//$$         if (!FlowingFluids.config.isFluidAllowed(fluidState)) {
+//$$             return true;
+//$$         }
+//$$
+//$$         return false;
+//$$     }
+
 //$$ }
 //#endif


### PR DESCRIPTION
## Summary

Fixes a [fluid duplication issue](https://github.com/Traben-0/flowing_fluids/issues/144) with Create open-ended pipes when extracting Flowing Fluids-managed fluids.

Create's `OpenEndedPipe.removeFluidFromSpace` can skip updating the world when vanilla fluid logic reports that the fluid source would immediately refill. With Flowing Fluids, this can extract fluid while leaving the source unchanged.

This PR disables that shortcut only for fluids managed by Flowing Fluids, allowing the existing removal path to continue and update the world.

## Changes

- Wraps the `potentiallyFilled.equals(fluidState)` check in `removeFluidFromSpace`.
- Preserves Create behavior when:
  - Flowing Fluids is disabled;
  - `create_infinitePipes` is enabled;
  - the fluid is not managed by Flowing Fluids.
- Keeps the existing `setBlock` argument modification path intact.

## Testing

Tested manually on NeoForge 1.21.1 with:
- Create mechanical pump
- Create open-ended pipe
- Flowing Fluids enabled
- finite pipe behavior enabled

Confirmed that extracting fluid no longer succeeds while leaving the source unchanged.