### PR TITLE
GH Actions improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,8 @@ jobs:
           distribution: temurin
           java-version: 25
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
       # Build the mod
       - run: ./gradlew build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,11 @@ jobs:
 
       # Build the mod
       - run: ./gradlew build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flowing_fluids-all
+          path: |
+            **/build/libs/*.jar
+            !**/build/libs/*-sources.jar
+            !**/build/libs/*-dev.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,15 @@ jobs:
       # Build the mod
       - run: ./gradlew build
 
+      # Collect all built JARs into a flat directory
+      - run: |
+          mkdir -p jars
+          find . -path "**/build/libs/*.jar" \
+            ! -name "*-sources.jar" \
+            ! -name "*-dev.jar" \
+            -exec cp {} jars/ \;
+
       - uses: actions/upload-artifact@v7
         with:
           name: flowing_fluids-all
-          path: |
-            **/build/libs/*.jar
-            !**/build/libs/*-sources.jar
-            !**/build/libs/*-dev.jar
+          path: jars/*.jar


### PR DESCRIPTION
Added `gradle/actions/setup-gradle@v6` for caching - sped up building from ~37 minutes to ~5 minutes after the first run.
Uploading built artifacts for easier access to dev builds.