### PR TITLE
Minor performance tweaks

### DIFF
--- a/src/main/java/traben/flowing_fluids/FFFluidUtils.java
+++ b/src/main/java/traben/flowing_fluids/FFFluidUtils.java
@@ -1,5 +1,6 @@
 package traben.flowing_fluids;
 
+import com.google.common.collect.Collections2;
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import net.minecraft.core.BlockPos;
@@ -45,6 +46,8 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 public class FFFluidUtils {
+    private static final List<List<Direction>> HORIZONTAL_PERMUTATIONS =
+            List.copyOf(Collections2.permutations(Direction.Plane.HORIZONTAL.stream().toList()));
 
     public static int seaLevel(LevelReader level) {
         // Dimension override
@@ -433,7 +436,7 @@ public class FFFluidUtils {
     }
 
     public static List<Direction> getCardinalsShuffle(RandomSource random) {
-        return Direction.Plane.HORIZONTAL.shuffledCopy(random);
+        return HORIZONTAL_PERMUTATIONS.get(random.nextInt(HORIZONTAL_PERMUTATIONS.size()));
     }
 
 

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -146,7 +146,7 @@ public abstract class MixinFlowingFluid extends Fluid {
 
             final int amountLess = amount - 1;
 
-            final Direction randomDirection = FFFluidUtils.getCardinalsShuffle(level.getRandom()).get(0);
+            final Direction randomDirection = Direction.Plane.HORIZONTAL.getRandomDirection(level.getRandom());
 
             BiConsumer<BlockPos.MutableBlockPos, BlockPos.MutableBlockPos> move;
             if(level.getRandom().nextBoolean()){

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -2,6 +2,8 @@ package traben.flowing_fluids.mixin.mixins;
 
 
 import it.unimi.dsi.fastutil.Pair;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2BooleanMap;
 import it.unimi.dsi.fastutil.shorts.Short2BooleanOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
@@ -9,8 +11,6 @@ import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockGetter;
@@ -18,7 +18,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.LightLayer;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BucketPickup;
 import net.minecraft.world.level.block.DirectionalBlock;
@@ -28,7 +27,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -50,9 +48,6 @@ import traben.flowing_fluids.config.FFConfig;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import static traben.flowing_fluids.FFFluidUtils.getStateForFluidByAmount;
@@ -519,34 +514,44 @@ public abstract class MixinFlowingFluid extends Fluid {
         // state cache for each position
         Short2ObjectMap<Pair<BlockState, FluidState>> statesAtPos = new Short2ObjectOpenHashMap<>();
 
-        //  flags if we should perform checks to override the slope requirement
-        AtomicBoolean anyFlowableNeighbours2LevelsLowerOrMore = new AtomicBoolean(requiresSlope);
+        // flags if we should perform checks to override the slope requirement
+        boolean anyFlowableNeighbours2LevelsLowerOrMore = requiresSlope;
 
         // get the cardinal directions that are valid flow locations sorted by the amount of fluid in them,
         // ties are randomly sorted by initial shuffle
-        List<Direction> directionsCanSpreadToSortedByAmount = FFFluidUtils.getCardinalsShuffle(level.random).stream()
-                .sorted(Comparator.comparingInt((dir1) -> level.getFluidState(blockPos.relative(dir1)).getAmount()))
-                .filter(dir -> {
-                    BlockPos posDir = blockPos.relative(dir);
-                    short key = ffCacheKey(blockPos, posDir);
-                    var statesDir = flowing_fluids$getSetPosCache(key, level, statesAtPos, posDir);
-                    BlockState stateDir = statesDir.first();
-                    var fluidStateDir = statesDir.second();
-                    int amountDir = fluidStateDir.getAmount();
-                    boolean canFlow = flowing_fluids$canSpreadToOptionallySameOrEmpty(fluidState.getType(), amount, level, blockPos,
-                            level.getBlockState(blockPos), dir, posDir, stateDir, fluidStateDir, requiresSlope);
-                    if (canFlow && !anyFlowableNeighbours2LevelsLowerOrMore.get()) {
-                        anyFlowableNeighbours2LevelsLowerOrMore.set(amountDir < amount - 1);
-                    }
-                    return canFlow;
-                })
-                .toList();
+        List<Direction> toSort = new ArrayList<>(FFFluidUtils.getCardinalsShuffle(level.random));
+        // cache the fluid amounts, as getting fluid states is somewhat expensive
+        Object2IntMap<Direction> fluidAmounts = new Object2IntOpenHashMap<>(4);
+        for (Direction dir : toSort) {
+            fluidAmounts.put(dir, level.getFluidState(blockPos.relative(dir)).getAmount());
+        }
+        toSort.sort(Comparator.comparingInt(fluidAmounts::getInt));
+
+        List<Direction> directionsCanSpreadToSortedByAmount = new ArrayList<>();
+        final int amountMinusOne = amount - 1;
+
+        for (Direction direction : toSort) {
+            BlockPos posDir = blockPos.relative(direction);
+            var statesDir = flowing_fluids$getSetPosCache(ffCacheKey(blockPos, posDir), level, statesAtPos, posDir);
+            BlockState stateDir = statesDir.first();
+            var fluidStateDir = statesDir.second();
+            int amountDir = fluidStateDir.getAmount();
+            boolean canFlow = flowing_fluids$canSpreadToOptionallySameOrEmpty(
+                    fluidState.getType(), amount, level, blockPos,
+                    level.getBlockState(blockPos), direction, posDir, stateDir, fluidStateDir, requiresSlope);
+            if (canFlow) {
+                if (!anyFlowableNeighbours2LevelsLowerOrMore) {
+                    anyFlowableNeighbours2LevelsLowerOrMore = amountDir < amountMinusOne;
+                }
+                directionsCanSpreadToSortedByAmount.add(direction);
+            }
+        }
 
         // early escape if no valid neighbours to spread too
         if (directionsCanSpreadToSortedByAmount.isEmpty()) return null;
 
         // force require slope to true if no neighbours are 2 levels lower or more, ignore override if forceFluidLeveling is enabled
-        boolean requiresSlopeWithOverride = requiresSlope || !anyFlowableNeighbours2LevelsLowerOrMore.get();
+        boolean requiresSlopeWithOverride = requiresSlope || !anyFlowableNeighbours2LevelsLowerOrMore;
 
         // perform a deep search for the best direction to spread to with the nearest slope
         Direction spreadDirection = flowing_fluids$getValidDirectionFromDeepSpreadSearch(level, blockPos, fluidState, amount, requiresSlopeWithOverride, directionsCanSpreadToSortedByAmount, statesAtPos);
@@ -577,26 +582,29 @@ public abstract class MixinFlowingFluid extends Fluid {
         // if we need to perform a deeper search
         // check if we can flow down here, if so, return the direction
         // else, perform a deep search for the nearest slope
-        return directionsCanSpreadToSortedByAmount.stream()
-                .map(dir -> {
-                    // we already know we can spread to this direction, so we can just check if we can flow down or
-                    // if we need to perform a deeper search
-                    var posDir = blockPos.relative(dir);
-                    short key = ffCacheKey(blockPos, posDir);
-                    // check if we can flow down here, if so, return the direction
-                    if (level.getFluidState(posDir).getAmount() < (amount - 1) || flowing_fluids$getSetFlowDownCache(key, level, posCanFlowDown, posDir, fluidState.getType(), requiresSlope)) {
-                        return Pair.of(dir, 0);
-                    } else {
-                        // else, perform a deep search for the nearest slope
-                        return Pair.of(dir, flowing_fluids$getSlopeDistance(
-                                level, blockPos, 1, dir.getOpposite(),
-                                fluidState.getType(), amount + 1, posDir, statesAtPos,
-                                posCanFlowDown, requiresSlope, slopeFindDistance));
-                    }
-                })
-                .filter(pair -> !requiresSlope || pair.second() <= slopeFindDistance)
-                .min(Comparator.comparingInt(Pair::second))
-                .map(Pair::first).orElse(null);
+        Direction bestDirection = null;
+        int minimalDistance = Integer.MAX_VALUE;
+
+        for (Direction dir : directionsCanSpreadToSortedByAmount) {
+            var posDir = blockPos.relative(dir);
+            short key = ffCacheKey(blockPos, posDir);
+            int distance;
+            if (level.getFluidState(posDir).getAmount() < (amount - 1) || flowing_fluids$getSetFlowDownCache(key, level, posCanFlowDown, posDir, fluidState.getType(), requiresSlope)) {
+                distance = 0;
+            } else {
+                distance = flowing_fluids$getSlopeDistance(
+                        level, blockPos, 1, dir.getOpposite(),
+                        fluidState.getType(), amount + 1, posDir, statesAtPos,
+                        posCanFlowDown, requiresSlope, slopeFindDistance);
+            }
+            if (!requiresSlope || distance <= slopeFindDistance) {
+                if (distance < minimalDistance) {
+                    minimalDistance = distance;
+                    bestDirection = dir;
+                }
+            }
+        }
+        return bestDirection;
     }
 
     @Unique

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -76,7 +76,7 @@ public abstract class MixinFlowingFluid extends Fluid {
                                                                       final BlockState thisState, final BlockPos posTo, final int destFluidAmount,
                                                                       boolean flowingDown
     ) {
-        //check if either too or from is water loggable and if so exit early if we cannot perform this flow due to settings
+        //check if either to or from is water loggable and if so exit early if we cannot perform this flow due to settings
         boolean fromIsWaterloggable = thisState.getBlock() instanceof LiquidBlockContainer && thisState.getBlock() instanceof BucketPickup;
         if (fromIsWaterloggable
                 && (flowingDown ? //cannot flow out
@@ -262,15 +262,21 @@ public abstract class MixinFlowingFluid extends Fluid {
                 return; // do not calculate and delay the tick
             }
 
-            if (System.currentTimeMillis() < FlowingFluids.debug_killFluidUpdatesUntilTime) {
-                return; // kill this update
+            if (FlowingFluids.debug_killFluidUpdatesUntilTime > 0) {
+                long diff = FlowingFluids.debug_killFluidUpdatesUntilTime - System.currentTimeMillis();
+                if (diff > 0) {
+                    return; // kill this update
+                } else {
+                    FlowingFluids.debug_killFluidUpdatesUntilTime = 0;
+                }
             }
 
             FlowingFluids.isManeuveringFluids = true;
 
+            int seaLevel = FFFluidUtils.seaLevel(level);
             boolean withinInfBiomeHeights = FlowingFluids.config.fastBiomeRefillAtSeaLevelOnly
-                    ? FFFluidUtils.seaLevel(level) == blockPos.getY() || FFFluidUtils.seaLevel(level) - 1 == blockPos.getY()
-                    : FFFluidUtils.seaLevel(level) == blockPos.getY() && blockPos.getY() > 0;
+                    ? seaLevel == blockPos.getY() || seaLevel - 1 == blockPos.getY()
+                    : seaLevel == blockPos.getY() && blockPos.getY() > 0;
 
             boolean isWaterAndInfiniteBiome = fluidState.is(FluidTags.WATER)
                     && withinInfBiomeHeights
@@ -278,7 +284,7 @@ public abstract class MixinFlowingFluid extends Fluid {
                     && level.getBrightness(LightLayer.SKY, blockPos) > 0;
 
             boolean dontConsumeWater = isWaterAndInfiniteBiome
-                    && FFFluidUtils.seaLevel(level) != blockPos.getY()
+                    && seaLevel != blockPos.getY()
                     && level.getRandom().nextFloat() < FlowingFluids.config.infiniteWaterBiomeNonConsumeChance;
 
             //#if MC <= 12100
@@ -354,7 +360,7 @@ public abstract class MixinFlowingFluid extends Fluid {
             } finally {
 
                 if (isWaterAndInfiniteBiome) {
-                    if (FFFluidUtils.seaLevel(level) == blockPos.getY()) {
+                    if (seaLevel == blockPos.getY()) {
                         var amount = level.getFluidState(blockPos).getAmount();
                         if (amount > 0) {
                             if (amount <= getDropOff(level) || level.getRandom().nextFloat() < FlowingFluids.config.infiniteWaterBiomeDrainSurfaceChance) {

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -520,7 +520,7 @@ public abstract class MixinFlowingFluid extends Fluid {
         // get the cardinal directions that are valid flow locations sorted by the amount of fluid in them,
         // ties are randomly sorted by initial shuffle
         List<Direction> toSort = new ArrayList<>(FFFluidUtils.getCardinalsShuffle(level.random));
-        // cache the fluid amounts, as getting fluid states is somewhat expensive
+        // cache the fluid amounts, as getting fluid states is somewhat expensive when doing a lot
         Object2IntMap<Direction> fluidAmounts = new Object2IntOpenHashMap<>(4);
         for (Direction dir : toSort) {
             fluidAmounts.put(dir, level.getFluidState(blockPos.relative(dir)).getAmount());
@@ -536,8 +536,7 @@ public abstract class MixinFlowingFluid extends Fluid {
             BlockState stateDir = statesDir.first();
             var fluidStateDir = statesDir.second();
             int amountDir = fluidStateDir.getAmount();
-            boolean canFlow = flowing_fluids$canSpreadToOptionallySameOrEmpty(
-                    fluidState.getType(), amount, level, blockPos,
+            boolean canFlow = flowing_fluids$canSpreadToOptionallySameOrEmpty(fluidState.getType(), amount, level, blockPos,
                     level.getBlockState(blockPos), direction, posDir, stateDir, fluidStateDir, requiresSlope);
             if (canFlow) {
                 if (!anyFlowableNeighbours2LevelsLowerOrMore) {
@@ -586,12 +585,16 @@ public abstract class MixinFlowingFluid extends Fluid {
         int minimalDistance = Integer.MAX_VALUE;
 
         for (Direction dir : directionsCanSpreadToSortedByAmount) {
+            // we already know we can spread to this direction, so we can just check if we can flow down or
+            // if we need to perform a deeper search
             var posDir = blockPos.relative(dir);
             short key = ffCacheKey(blockPos, posDir);
             int distance;
+            // check if we can flow down here, if so, return the direction
             if (level.getFluidState(posDir).getAmount() < (amount - 1) || flowing_fluids$getSetFlowDownCache(key, level, posCanFlowDown, posDir, fluidState.getType(), requiresSlope)) {
                 distance = 0;
             } else {
+                // else, perform a deep search for the nearest slope
                 distance = flowing_fluids$getSlopeDistance(
                         level, blockPos, 1, dir.getOpposite(),
                         fluidState.getType(), amount + 1, posDir, statesAtPos,


### PR DESCRIPTION
While testing the performance with Spark, I've stumbled upon a few hot spots:
- I was surprised seeing `System.currentTimeMillis()` as a cause of a hot spot, but I've tested it multiple times, and all of them had a few percents claimed by it. Since this is a debug'ish feature, I've added a check to skip calling it.
- Removed some world look ups by caching.
- Replaced two streams with for-each equivalents for some little gains. 
But of course, the main lag contributor is setting block on Level, which I'm too afraid to tackle for now.