### PR TITLE
Add naive compat with 3D rivers

### DIFF
--- a/src/main/java/traben/flowing_fluids/FFFluidUtils.java
+++ b/src/main/java/traben/flowing_fluids/FFFluidUtils.java
@@ -13,11 +13,13 @@ import net.minecraft.data.worldgen.DimensionTypes;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
@@ -595,6 +597,16 @@ public class FFFluidUtils {
                 || FlowingFluids.infiniteBiomes.stream().anyMatch(biome::is);
     }
 
+    public static boolean isPreservedVanillaWater(
+            final Level level,
+            final BlockPos pos,
+            final FluidState fluidState
+    ) {
+        return FlowingFluids.config.preserveVanillaWaterInInfiniteBiomes
+                && fluidState.is(FluidTags.WATER)
+                && matchInfiniteBiomes(level.getBiome(pos))
+                && level.getBrightness(LightLayer.SKY, pos) > 0;
+    }
 
     private static long lastFlowSoundTime = 0;
 

--- a/src/main/java/traben/flowing_fluids/config/FFCommands.java
+++ b/src/main/java/traben/flowing_fluids/config/FFCommands.java
@@ -750,6 +750,14 @@ public class FFCommands {
                                         "Liquids at their minimum height will now flow to and over nearby edges, up to 4 blocks away.",
                                         "Liquids at their minimum height will no longer flow to and over nearby edges.",
                                         a -> FlowingFluids.config.flowToEdges = a, () -> FlowingFluids.config.flowToEdges)
+                                ).then(booleanCommand(
+                                        "preserve_vanilla_water_in_wet_biomes",
+                                        "When enabled, source water blocks (8/8) in ocean, river, and swamp biomes will not be processed " +
+                                                "by Flowing Fluids, preserving the original water layout (useful for 3D rivers). " +
+                                                "NOTE: It is strongly recommended to also set the sea level override to a high " +
+                                                "value (e.g. 4096) via /flowingfluids advancedsettings sealeveloverride. ",
+                                        a -> FlowingFluids.config.preserveVanillaWaterInWetBiomes = a,
+                                        () -> FlowingFluids.config.preserveVanillaWaterInWetBiomes)
                                 )
                         ).then(drainAndFill()
                         )

--- a/src/main/java/traben/flowing_fluids/config/FFCommands.java
+++ b/src/main/java/traben/flowing_fluids/config/FFCommands.java
@@ -18,6 +18,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -755,7 +756,9 @@ public class FFCommands {
                                         "When enabled, source water blocks (8/8) in ocean, river, and swamp biomes will not be processed " +
                                                 "by Flowing Fluids, preserving the original water layout (useful for 3D rivers). " +
                                                 "NOTE: It is strongly recommended to also set the sea level override to a high " +
-                                                "value (e.g. 4096) via /flowingfluids advancedsettings sealeveloverride. ",
+                                                "value (e.g. 4096) via /flowingfluids advancedsettings sealeveloverride. " +
+                                                "You should set /gamerule waterSourceConversion false, otherwise vanilla " +
+                                                "water mechanics may create infinite water sources in these biomes.",
                                         a -> FlowingFluids.config.preserveVanillaWaterInWetBiomes = a,
                                         () -> FlowingFluids.config.preserveVanillaWaterInWetBiomes)
                                 )

--- a/src/main/java/traben/flowing_fluids/config/FFCommands.java
+++ b/src/main/java/traben/flowing_fluids/config/FFCommands.java
@@ -18,7 +18,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -751,16 +750,15 @@ public class FFCommands {
                                         "Liquids at their minimum height will now flow to and over nearby edges, up to 4 blocks away.",
                                         "Liquids at their minimum height will no longer flow to and over nearby edges.",
                                         a -> FlowingFluids.config.flowToEdges = a, () -> FlowingFluids.config.flowToEdges)
-                                ).then(booleanCommand(
-                                        "preserve_vanilla_water_in_wet_biomes",
-                                        "When enabled, source water blocks (8/8) in ocean, river, and swamp biomes will not be processed " +
-                                                "by Flowing Fluids, preserving the original water layout (useful for 3D rivers). " +
-                                                "NOTE: It is strongly recommended to also set the sea level override to a high " +
-                                                "value (e.g. 4096) via /flowingfluids advancedsettings sealeveloverride. " +
-                                                "You should set /gamerule waterSourceConversion false, otherwise vanilla " +
-                                                "water mechanics may create infinite water sources in these biomes.",
-                                        a -> FlowingFluids.config.preserveVanillaWaterInWetBiomes = a,
-                                        () -> FlowingFluids.config.preserveVanillaWaterInWetBiomes)
+                                ).then(booleanCommand("preserve_vanilla_water_in_infinite_biomes",
+                                        "Prevents Flowing Fluids from processing water exposed to sky light in infinite water biomes, preserving the original water layout.\n" +
+                                                "By default, infinite water biomes are oceans, rivers, and swamps. This is useful for 3D river mods.\n" +
+                                                "NOTE: It is strongly recommended to set the sea level override to a high value (e.g. 4096) via " +
+                                                "/flowingfluids advanced_settings sea_level_override.\n" +
+                                                "You should also set /gamerule waterSourceConversion false to prevent vanilla water mechanics from " +
+                                                "creating infinite water sources in these biomes.",
+                                        a -> FlowingFluids.config.preserveVanillaWaterInInfiniteBiomes = a,
+                                        () -> FlowingFluids.config.preserveVanillaWaterInInfiniteBiomes)
                                 )
                         ).then(drainAndFill()
                         )

--- a/src/main/java/traben/flowing_fluids/config/FFConfig.java
+++ b/src/main/java/traben/flowing_fluids/config/FFConfig.java
@@ -48,7 +48,7 @@ public class FFConfig {
     public boolean waterFlowAffectsEntities = true;
     public boolean waterFlowAffectsPlayers = false;
     public boolean waterFlowAffectsItems = true;
-    public boolean preserveVanillaWaterInWetBiomes = false;
+    public boolean preserveVanillaWaterInInfiniteBiomes = false;
     public float infiniteWaterBiomeNonConsumeChance = 0.01f;
     public float infiniteWaterBiomeDrainSurfaceChance = 0.5f;
     public int minWaterLevelForIce = 4;
@@ -186,7 +186,7 @@ public class FFConfig {
         displacementSounds = buffer.readEnum(DisplacementSounds.class);
         flowSoundChance = buffer.readFloat();
         tickDelaySpread = buffer.readVarInt();
-        preserveVanillaWaterInWetBiomes = buffer.readBoolean();
+        preserveVanillaWaterInInfiniteBiomes = buffer.readBoolean();
 
         // Auto performance handling
         autoPerformanceMode = buffer.readEnum(AutoPerformance.class);
@@ -257,7 +257,7 @@ public class FFConfig {
         buffer.writeEnum(displacementSounds);
         buffer.writeFloat(flowSoundChance);
         buffer.writeVarInt(tickDelaySpread);
-        buffer.writeBoolean(preserveVanillaWaterInWetBiomes);
+        buffer.writeBoolean(preserveVanillaWaterInInfiniteBiomes);
 
         // Auto performance handling
         buffer.writeEnum(autoPerformanceMode);

--- a/src/main/java/traben/flowing_fluids/config/FFConfig.java
+++ b/src/main/java/traben/flowing_fluids/config/FFConfig.java
@@ -48,6 +48,7 @@ public class FFConfig {
     public boolean waterFlowAffectsEntities = true;
     public boolean waterFlowAffectsPlayers = false;
     public boolean waterFlowAffectsItems = true;
+    public boolean preserveVanillaWaterInWetBiomes = false;
     public float infiniteWaterBiomeNonConsumeChance = 0.01f;
     public float infiniteWaterBiomeDrainSurfaceChance = 0.5f;
     public int minWaterLevelForIce = 4;
@@ -185,6 +186,7 @@ public class FFConfig {
         displacementSounds = buffer.readEnum(DisplacementSounds.class);
         flowSoundChance = buffer.readFloat();
         tickDelaySpread = buffer.readVarInt();
+        preserveVanillaWaterInWetBiomes = buffer.readBoolean();
 
         // Auto performance handling
         autoPerformanceMode = buffer.readEnum(AutoPerformance.class);
@@ -255,6 +257,7 @@ public class FFConfig {
         buffer.writeEnum(displacementSounds);
         buffer.writeFloat(flowSoundChance);
         buffer.writeVarInt(tickDelaySpread);
+        buffer.writeBoolean(preserveVanillaWaterInWetBiomes);
 
         // Auto performance handling
         buffer.writeEnum(autoPerformanceMode);

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -60,6 +61,8 @@ public abstract class MixinBucketItem extends Item implements FFBucketItem {
     @Final
     private Fluid content;
 
+    @Unique
+    private static final ThreadLocal<Boolean> ff$preserveVanillaForThisUse = ThreadLocal.withInitial(() -> false);
     public MixinBucketItem(final Properties properties) {
         super(properties);
     }
@@ -83,6 +86,9 @@ public abstract class MixinBucketItem extends Item implements FFBucketItem {
             index = 2
     )
     private ClipContext.Fluid flowing_fluids$allowAnyFluid(final ClipContext.Fluid par3) {
+        if (ff$preserveVanillaForThisUse.get()) {
+            return par3;
+        }
         if (FlowingFluids.config.enableMod && par3 == ClipContext.Fluid.SOURCE_ONLY) {
             return ClipContext.Fluid.ANY;
         }
@@ -98,6 +104,28 @@ public abstract class MixinBucketItem extends Item implements FFBucketItem {
                                                         //$$ CallbackInfoReturnable<InteractionResultHolder<ItemStack>> cir
                                                         //#endif
     ) {
+        ff$preserveVanillaForThisUse.set(false);
+        if (FlowingFluids.config.enableMod
+                && this.content == Fluids.EMPTY
+                && FlowingFluids.config.preserveVanillaWaterInWetBiomes) {
+
+            BlockHitResult anyHit = getPlayerPOVHitResult(level, player, ClipContext.Fluid.ANY);
+
+            if (anyHit.getType() == HitResult.Type.BLOCK) {
+                BlockPos pos = anyHit.getBlockPos();
+                var fluidState = level.getFluidState(pos);
+                boolean isRiverBiome = FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos));
+
+                if (fluidState.is(FluidTags.WATER) && isRiverBiome) {
+                    if (fluidState.getAmount() < 8) {
+                        ff$preserveVanillaForThisUse.set(true);
+                        return;
+                    }
+                    ff$preserveVanillaForThisUse.set(true);
+                    return;
+                }
+            }
+        }
         if (FlowingFluids.config.enableMod
                 && content instanceof FlowingFluid
                 && FlowingFluids.config.isFluidAllowed(content)

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
@@ -105,22 +105,14 @@ public abstract class MixinBucketItem extends Item implements FFBucketItem {
                                                         //#endif
     ) {
         ff$preserveVanillaForThisUse.set(false);
-        if (FlowingFluids.config.enableMod
-                && this.content == Fluids.EMPTY
-                && FlowingFluids.config.preserveVanillaWaterInWetBiomes) {
-
+        if (this.content == Fluids.EMPTY) {
             BlockHitResult anyHit = getPlayerPOVHitResult(level, player, ClipContext.Fluid.ANY);
 
             if (anyHit.getType() == HitResult.Type.BLOCK) {
                 BlockPos pos = anyHit.getBlockPos();
                 var fluidState = level.getFluidState(pos);
-                boolean isRiverBiome = FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos));
 
-                if (fluidState.is(FluidTags.WATER) && isRiverBiome) {
-                    if (fluidState.getAmount() < 8) {
-                        ff$preserveVanillaForThisUse.set(true);
-                        return;
-                    }
+                if (FFFluidUtils.isPreservedVanillaWater(level, pos, fluidState)) {
                     ff$preserveVanillaForThisUse.set(true);
                     return;
                 }

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 import static traben.flowing_fluids.FFFluidUtils.getStateForFluidByAmount;
+import static traben.flowing_fluids.FFFluidUtils.matchInfiniteBiomes;
 
 
 @Mixin(FlowingFluid.class)
@@ -138,6 +140,7 @@ public abstract class MixinFlowingFluid extends Fluid {
                 && level.getChunkAt(pos).getFluidTicks().count() < 16 //ignore chunks with many updating fluids
                 && FlowingFluids.config.isFluidAllowed(this)
                 && !level.getFluidState(pos.above()).getType().isSame(this)//don't settle if there is a fluid above
+                && !FFFluidUtils.isPreservedVanillaWater(level, pos, state)
         ) {
             //search in a random direction up to 32 blocks for a lower fluid to level out with
 
@@ -247,11 +250,9 @@ public abstract class MixinFlowingFluid extends Fluid {
                     BlockState thisState,
                     //#endif
                     final FluidState fluidState, final CallbackInfo ci) {
-        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes
-                && fluidState.is(FluidTags.WATER)
-                && FFFluidUtils.matchInfiniteBiomes(level.getBiome(blockPos))) {
-            return;
-        }
+          if(FFFluidUtils.isPreservedVanillaWater(level, blockPos, fluidState)) {
+              return;
+          }
         if (FlowingFluids.config.enableMod
                 && FlowingFluids.config.isFluidAllowed(fluidState)) {
             // cancel the original tick
@@ -280,7 +281,7 @@ public abstract class MixinFlowingFluid extends Fluid {
 
             boolean isWaterAndInfiniteBiome = fluidState.is(FluidTags.WATER)
                     && withinInfBiomeHeights
-                    && FFFluidUtils.matchInfiniteBiomes(level.getBiome(blockPos))
+                    && matchInfiniteBiomes(level.getBiome(blockPos))
                     && level.getBrightness(LightLayer.SKY, blockPos) > 0;
 
             boolean dontConsumeWater = isWaterAndInfiniteBiome
@@ -505,7 +506,15 @@ public abstract class MixinFlowingFluid extends Fluid {
             //$$ Level level,
             //#endif
             final BlockPos blockPos, final BlockState blockState, final CallbackInfoReturnable<FluidState> cir) {
-        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes){
+        // TODO: using this check did not work correctly - had to use this condition directly instead.
+        //  Not sure why the shared helper behaves differently in this specific method.
+        // if (FFFluidUtils.isPreservedVanillaWater(level, blockPos, level.getFluidState(blockPos))) {
+        //     return;
+        // }
+        if (FlowingFluids.config.preserveVanillaWaterInInfiniteBiomes
+                && this.isSame(Fluids.WATER)
+                && matchInfiniteBiomes(level.getBiome(blockPos))
+                && level.getBrightness(LightLayer.SKY, blockPos) > 0) {
             return;
         }
         if (FlowingFluids.config.enableMod

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -247,6 +247,7 @@ public abstract class MixinFlowingFluid extends Fluid {
                     BlockState thisState,
                     //#endif
                     final FluidState fluidState, final CallbackInfo ci) {
+        if (flowing_fluids$shouldPreserveVanilla(level, blockPos, fluidState)) { return; }
         if (FlowingFluids.config.enableMod
                 && FlowingFluids.config.isFluidAllowed(fluidState)) {
             // cancel the original tick
@@ -712,5 +713,23 @@ public abstract class MixinFlowingFluid extends Fluid {
                                                BlockPos blockPos2, BlockState blockState2, FluidState fluidState2) {
         //add extra fluid check for replacing into self
         return FFFluidUtils.canFluidFlowFromPosToDirection((FlowingFluid) sourceFluid, sourceAmount, blockGetter, blockPos, blockState, direction, blockPos2, blockState2, fluidState2);
+    }
+
+    @Unique
+    private static boolean flowing_fluids$shouldPreserveVanilla(Level level, BlockPos pos, FluidState fluidState) {
+        if (!FlowingFluids.config.preserveVanillaWaterInWetBiomes) return false;
+        if (fluidState == null || !fluidState.is(FluidTags.WATER)) return false;
+        if (!FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos))) return false;
+
+        // Allow water to fall freely downward
+        BlockPos below = pos.below();
+        FluidState belowFluid = level.getFluidState(below);
+        if (level.getBlockState(below).isAir()
+                || (!belowFluid.isEmpty() && belowFluid.getAmount() < 8)) return false;
+
+        // Flowing water (amount < 4) is handled normally by Flowing Fluids
+        if (fluidState.getAmount() < 4) return false;
+
+        return true;
     }
 }

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinFlowingFluid.java
@@ -247,7 +247,11 @@ public abstract class MixinFlowingFluid extends Fluid {
                     BlockState thisState,
                     //#endif
                     final FluidState fluidState, final CallbackInfo ci) {
-        if (flowing_fluids$shouldPreserveVanilla(level, blockPos, fluidState)) { return; }
+        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes
+                && fluidState.is(FluidTags.WATER)
+                && FFFluidUtils.matchInfiniteBiomes(level.getBiome(blockPos))) {
+            return;
+        }
         if (FlowingFluids.config.enableMod
                 && FlowingFluids.config.isFluidAllowed(fluidState)) {
             // cancel the original tick
@@ -501,6 +505,9 @@ public abstract class MixinFlowingFluid extends Fluid {
             //$$ Level level,
             //#endif
             final BlockPos blockPos, final BlockState blockState, final CallbackInfoReturnable<FluidState> cir) {
+        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes){
+            return;
+        }
         if (FlowingFluids.config.enableMod
                 && FlowingFluids.config.isFluidAllowed(this)) {
             var state = level.getFluidState(blockPos);
@@ -713,23 +720,5 @@ public abstract class MixinFlowingFluid extends Fluid {
                                                BlockPos blockPos2, BlockState blockState2, FluidState fluidState2) {
         //add extra fluid check for replacing into self
         return FFFluidUtils.canFluidFlowFromPosToDirection((FlowingFluid) sourceFluid, sourceAmount, blockGetter, blockPos, blockState, direction, blockPos2, blockState2, fluidState2);
-    }
-
-    @Unique
-    private static boolean flowing_fluids$shouldPreserveVanilla(Level level, BlockPos pos, FluidState fluidState) {
-        if (!FlowingFluids.config.preserveVanillaWaterInWetBiomes) return false;
-        if (fluidState == null || !fluidState.is(FluidTags.WATER)) return false;
-        if (!FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos))) return false;
-
-        // Allow water to fall freely downward
-        BlockPos below = pos.below();
-        FluidState belowFluid = level.getFluidState(below);
-        if (level.getBlockState(below).isAir()
-                || (!belowFluid.isEmpty() && belowFluid.getAmount() < 8)) return false;
-
-        // Flowing water (amount < 4) is handled normally by Flowing Fluids
-        if (fluidState.getAmount() < 4) return false;
-
-        return true;
     }
 }

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
@@ -50,10 +50,8 @@ public abstract class MixinLevel implements FFFlowListenerLevel {
                     target = "Lnet/minecraft/world/level/Level;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"))
     private void flowing_fluids$displaceFluids(final BlockPos pos, final BlockState state, final int flags, final int recursionLeft, final CallbackInfoReturnable<Boolean> cir, @Local final LevelChunk levelChunk, @Local(ordinal = 1) final BlockState originalState) {
         Level level = (Level)(Object) this;
-        // skip displacement entirely in protected wet biomes - let vanilla water physics happen naturally
-        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes
-                && originalState.getFluidState().is(FluidTags.WATER)
-                && FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos))) {
+        // Preserve vanilla water layouts in infinite biomes by skipping Flowing Fluids displacement.
+        if (FFFluidUtils.isPreservedVanillaWater(level, pos, originalState.getFluidState())) {
             return;
         }
         FFFluidUtils.displaceFluids(level, pos, state, flags, levelChunk, originalState);

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
@@ -7,6 +7,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,6 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import traben.flowing_fluids.FFFlowListenerLevel;
 import traben.flowing_fluids.FFFluidUtils;
+import traben.flowing_fluids.FlowingFluids;
 import traben.flowing_fluids.IFFFlowListener;
 
 import java.util.List;
@@ -47,7 +49,14 @@ public abstract class MixinLevel implements FFFlowListenerLevel {
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/world/level/Level;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"))
     private void flowing_fluids$displaceFluids(final BlockPos pos, final BlockState state, final int flags, final int recursionLeft, final CallbackInfoReturnable<Boolean> cir, @Local final LevelChunk levelChunk, @Local(ordinal = 1) final BlockState originalState) {
-        FFFluidUtils.displaceFluids((Level) (Object) this, pos, state, flags, levelChunk, originalState);
+        Level level = (Level)(Object) this;
+        // skip displacement entirely in protected wet biomes - let vanilla water physics happen naturally
+        if (FlowingFluids.config.preserveVanillaWaterInWetBiomes
+                && originalState.getFluidState().is(FluidTags.WATER)
+                && FFFluidUtils.matchInfiniteBiomes(level.getBiome(pos))) {
+            return;
+        }
+        FFFluidUtils.displaceFluids(level, pos, state, flags, levelChunk, originalState);
     }
     //#endif
 

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinWaterFluid.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinWaterFluid.java
@@ -57,6 +57,8 @@ public abstract class MixinWaterFluid extends FlowingFluid {
 
         if (FlowingFluids.config.dontTickAtLocation(blockPos, level)) return; // do not calculate
 
+        if (FFFluidUtils.isPreservedVanillaWater(level, blockPos, fluidState)) return;
+
         int amount = fluidState.getAmount();
 
         // Twilight forest presents its fluid state as water at level 1


### PR DESCRIPTION
Adds a new config option "preserve_vanilla_water_in_wet_biomes" that prevents Flowing Fluids from processing water blocks in ocean, river, and swamp biomes. This is intended to preserve the original water layout generated by 3D river mods.

- Water can only fall downward, not spread horizontally. My attempts to allow 
  horizontal spreading without creating infinite 
  water sources failed. For now, only downward flow works correctly.
-  Because rivers can exist at any elevation, it is not possible to define a sensible default sea level. As a side effect, any water above or below a river biome will also be treated as "special" water, since there is no way to determine what counts as "surface level".
I am not fully satisfied with the current implementation and would appreciate any suggestions on how to improve it.

<img width="1920" height="1080" alt="2026-06-19_20 32 24" src="https://github.com/user-attachments/assets/e41c98b1-11f9-4f54-89f1-639b8ffa0af1" />
