### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,7 @@ dependencies {
 
     "SODIUM" setVar (
             modImpl("maven.modrinth:sodium:",
+                260200 to ver("2Yom1N68", null,  "KHPycol7"),
                 260100 to ver("Amr4VcZo", null,  "Fg5Mk6Y3"),
                 12109 to ver("sFfidWgd", null,  "PdQpfqPZ"),
                 12106 to ver("7pwil2dy", null,  "q6wdZywr"),
@@ -169,6 +170,7 @@ dependencies {
 
     if (platform.isFabric) {
         val fab = when {
+            mcVersion >= 26_02_00 -> "0.154.2+26.2"
             mcVersion >= 26_01_00 -> "0.143.14+26.1"
             mcVersion >= 1_21_09 -> "0.138.3+1.21.10"
             mcVersion >= 1_21_06 -> "0.128.2+1.21.6"

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     // Advanced users may use multiple (potentially independent) multi-version trees in different sub-projects.
     // This is currently equivalent to applying `com.replaymod.preprocess-root`.
     kotlin("jvm") version "2.3.0" apply false
-    id("gg.essential.loom") version "1.15.48" apply false // https://repo.essential.gg/#/public/gg/essential/loom/gg.essential.loom.gradle.plugin
+    id("gg.essential.loom") version "1.15.50" apply false // https://repo.essential.gg/#/public/gg/essential/loom/gg.essential.loom.gradle.plugin
     id("gg.essential.multi-version.root")
 }
 
@@ -53,7 +53,8 @@ preprocess {
     }
 
     // older
-    null.connectToVersion(26_01_00, forge = false, neoforge = true)
+    null.connectToVersion(26_02_00, forge = false, neoforge = true)
+        .connectToVersion(26_01_00, forge = false, neoforge = true)
         .connectToVersion(1_21_11)
         .connectToVersion(1_21_09)
         .connectToVersion(1_21_06)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ fun MutableList<String>.version(mcVersion: Int, forge: Boolean = true, neoforge:
 }
 
 mutableListOf<String>()
+    .version(26_02_00, forge = false, neoforge = true)
     .version(26_01_00, forge = false, neoforge = true)
     .version(1_21_11)
     .version(1_21_09)

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinBucketItem.java
@@ -1,7 +1,11 @@
 package traben.flowing_fluids.mixin.mixins;
 
 
+//#if MC >= 26.2
+//$$ import net.minecraft.advancements.triggers.CriteriaTriggers;
+//#else
 import net.minecraft.advancements.CriteriaTriggers;
+//#endif
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 //#if MC > 12001

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
@@ -1,5 +1,8 @@
 package traben.flowing_fluids.mixin.mixins;
 
+//#if NEOFORGE && MC >= 26.2
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+//#endif
 import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -25,12 +28,28 @@ import java.util.Set;
 @Mixin(Level.class)
 public abstract class MixinLevel implements FFFlowListenerLevel {
 
+    //#if NEOFORGE && MC >= 26.2
+    @ModifyExpressionValue(method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
+            at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/chunk/LevelChunk;setBlockState(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Lnet/minecraft/world/level/block/state/BlockState;"))
+    private BlockState flowing_fluids$displaceFluids(final BlockState originalState,
+                                                      @Local(argsOnly = true) final BlockPos pos,
+                                                      @Local(argsOnly = true) final BlockState state,
+                                                      @Local(argsOnly = true, ordinal = 0) final int flags,
+                                                      @Local final LevelChunk levelChunk) {
+        if (originalState != null) {
+            FFFluidUtils.displaceFluids((Level) (Object) this, pos, state, flags, levelChunk, originalState);
+        }
+        return originalState;
+    }
+    //#else
     @Inject(method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/world/level/Level;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"))
     private void flowing_fluids$displaceFluids(final BlockPos pos, final BlockState state, final int flags, final int recursionLeft, final CallbackInfoReturnable<Boolean> cir, @Local final LevelChunk levelChunk, @Local(ordinal = 1) final BlockState originalState) {
         FFFluidUtils.displaceFluids((Level) (Object) this, pos, state, flags, levelChunk, originalState);
     }
+    //#endif
 
     @Unique
     Object2ObjectOpenHashMap<BlockPos, Set<BlockPos>> ff$flowListenerPositions = null;

--- a/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
+++ b/src/main/java/traben/flowing_fluids/mixin/mixins/MixinLevel.java
@@ -1,7 +1,7 @@
 package traben.flowing_fluids.mixin.mixins;
 
 //#if NEOFORGE && MC >= 26.2
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+//$$ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 //#endif
 import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -29,19 +29,19 @@ import java.util.Set;
 public abstract class MixinLevel implements FFFlowListenerLevel {
 
     //#if NEOFORGE && MC >= 26.2
-    @ModifyExpressionValue(method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
-            at = @At(value = "INVOKE",
-                    target = "Lnet/minecraft/world/level/chunk/LevelChunk;setBlockState(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Lnet/minecraft/world/level/block/state/BlockState;"))
-    private BlockState flowing_fluids$displaceFluids(final BlockState originalState,
-                                                      @Local(argsOnly = true) final BlockPos pos,
-                                                      @Local(argsOnly = true) final BlockState state,
-                                                      @Local(argsOnly = true, ordinal = 0) final int flags,
-                                                      @Local final LevelChunk levelChunk) {
-        if (originalState != null) {
-            FFFluidUtils.displaceFluids((Level) (Object) this, pos, state, flags, levelChunk, originalState);
-        }
-        return originalState;
-    }
+    //$$ @ModifyExpressionValue(method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
+    //$$         at = @At(value = "INVOKE",
+    //$$                 target = "Lnet/minecraft/world/level/chunk/LevelChunk;setBlockState(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;I)Lnet/minecraft/world/level/block/state/BlockState;"))
+    //$$ private BlockState flowing_fluids$displaceFluids(final BlockState originalState,
+    //$$                                                   @Local(argsOnly = true) final BlockPos pos,
+    //$$                                                   @Local(argsOnly = true) final BlockState state,
+    //$$                                                   @Local(argsOnly = true, ordinal = 0) final int flags,
+    //$$                                                   @Local final LevelChunk levelChunk) {
+    //$$     if (originalState != null) {
+    //$$         FFFluidUtils.displaceFluids((Level) (Object) this, pos, state, flags, levelChunk, originalState);
+    //$$     }
+    //$$     return originalState;
+    //$$ }
     //#else
     @Inject(method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
             at = @At(value = "INVOKE",

--- a/versions/26.2-fabric/gradle.properties
+++ b/versions/26.2-fabric/gradle.properties
@@ -1,0 +1,3 @@
+essential.defaults.loom.minecraft=com.mojang:minecraft:26.2
+essential.defaults.loom.fabric-loader=net.fabricmc:fabric-loader:0.19.3
+essential.defaults.loom.mappings=

--- a/versions/26.2-neoforge/gradle.properties
+++ b/versions/26.2-neoforge/gradle.properties
@@ -1,0 +1,3 @@
+essential.defaults.loom.neoForge=net.neoforged:neoforge:26.2.0.18-beta
+essential.defaults.loom.minecraft=com.mojang:minecraft:26.2
+essential.defaults.loom.mappings=


### PR DESCRIPTION
Ports Flowing Fluids to Minecraft 26.2 across Fabric and NeoForge. Closing #185 

Main changes are:
- Add first-class 26.2 Fabric and NeoForge targets using Java 25 and official mappings.
- Update Loom, Fabric Loader/API, NeoForge, and Sodium dependencies for 26.2.
- Adapt the bucket advancement trigger import for the 26.2 API.
- Retarget NeoForge block displacement to `LevelChunk#setBlockState` after its `Level#setBlock` patch removed the previous mixin anchor.

Verification:
- Fabric client gameplay and fluid-flow smoke test.
- NeoForge dedicated server startup and clean shutdown.
- Fabric and NeoForge builds for 26.2, plus 26.1 regression builds.

https://github.com/user-attachments/assets/e74f68d8-55e0-4ad0-991e-35bd96ca14d5